### PR TITLE
Fix type error in python3 and add supersede host name

### DIFF
--- a/pypureomapi.py
+++ b/pypureomapi.py
@@ -1121,6 +1121,28 @@ class Omapi(object):
 		except KeyError: # hardware-address
 			raise OmapiErrorNotFound()
 
+	def add_host_supersede_name(omapi, ip, mac, name):
+		"""Add a host with a fixed-address and override its hostname with the given name.
+		@type omapi: Omapi
+		@type ip: str
+		@type mac: str
+		@type name: str
+		@raises ValueError:
+		@raises OmapiError:
+		@raises socket.error:
+		"""
+		msg = OmapiMessage.open(b"host")
+		msg.message.append((b"create", struct.pack("!I", 1)))
+		msg.message.append((b"exclusive", struct.pack("!I", 1)))
+		msg.obj.append((b"hardware-address", pack_mac(mac)))
+		msg.obj.append((b"hardware-type", struct.pack("!I", 1)))
+		msg.obj.append((b"ip-address", pack_ip(ip)))
+		msg.obj.append((b"name", name))
+		msg.obj.append((b"statement", str.encode("supersede host-name %s;" % name)))
+		response = omapi.query_server(msg)
+		if response.opcode != OMAPI_OP_UPDATE:
+			raise OmapiError("add failed")
+
 if __name__ == '__main__':
 	import doctest
 	doctest.testmod()


### PR DESCRIPTION
- Fix the type error in python3 for OmapiHMACMD5Authenticator()
- Add API add_host_supersede_name()
