### PR TITLE
Use six to avoid needless py2/py3 additions

### DIFF
--- a/pypureomapi.py
+++ b/pypureomapi.py
@@ -46,15 +46,12 @@ __all__ = []
 import binascii
 import struct
 import hmac
-import io
 import logging
 import socket
 import random
 import operator
-try:
-	basestring
-except NameError:
-	basestring = str  # pylint:disable=W0622
+
+import six
 
 logger = logging.getLogger("pypureomapi")
 sysrand = random.SystemRandom()
@@ -105,7 +102,7 @@ class OutBuffer(object):
 	sizelimit = 65536
 
 	def __init__(self):
-		self.buff = io.BytesIO()
+		self.buff = six.BytesIO()
 
 	def __len__(self):
 		"""Return the number of bytes in the buffer.
@@ -215,7 +212,7 @@ class OutBuffer(object):
 		@type length: int
 		@returns: self
 		"""
-		self.buff = io.BytesIO(self.getvalue()[length:])
+		self.buff = six.BytesIO(self.getvalue()[length:])
 		return self
 
 
@@ -717,7 +714,7 @@ def pack_ip(ipstr):
 	@rtype: bytes
 	@raises ValueError: for badly formatted ip addresses
 	"""
-	if not isinstance(ipstr, basestring):
+	if not isinstance(ipstr, six.string_types):
 		raise ValueError("given ip address is not a string")
 	parts = ipstr.split('.')
 	if len(parts) != 4:
@@ -743,8 +740,8 @@ def unpack_ip(fourbytes):
 	@rtype: str
 	@raises ValueError: for bad input
 	"""
-	if not isinstance(fourbytes, bytes):
-		raise ValueError("given buffer is not a string")
+	if not isinstance(fourbytes, six.binary_type):
+		raise ValueError("given buffer is not a binary string")
 	if len(fourbytes) != 4:
 		raise ValueError("given buffer is not exactly four bytes long")
 	return ".".join([str(x) for x in bytes_to_int_seq(fourbytes)])
@@ -768,7 +765,7 @@ def pack_mac(macstr):
 	@rtype: bytes
 	@raises ValueError: for badly formatted mac addresses
 	"""
-	if not isinstance(macstr, basestring):
+	if not isinstance(macstr, six.string_types):
 		raise ValueError("given mac addresses is not a string")
 	parts = macstr.split(":")
 	if len(parts) != 6:
@@ -794,8 +791,8 @@ def unpack_mac(sixbytes):
 	@rtype: str
 	@raises ValueError: for bad input
 	"""
-	if not isinstance(sixbytes, bytes):
-		raise ValueError("given buffer is not a string")
+	if not isinstance(sixbytes, six.binary_type):
+		raise ValueError("given buffer is not a binary string")
 	if len(sixbytes) != 6:
 		raise ValueError("given buffer is not exactly six bytes long")
 	return ":".join(["%2.2x".__mod__(x) for x in bytes_to_int_seq(sixbytes)])

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ distutils.core.setup(name='pypureomapi',
 	license='Apache-2.0',
 	url='https://github.com/CygnusNetworks/pypureomapi',
 	py_modules=['pypureomapi'],
+	install_requires=['six'],
 	classifiers=[
 		"Development Status :: 5 - Production/Stable",
 		"Intended Audience :: System Administrators",


### PR DESCRIPTION
The six module provides the same py2/py3 changes
that this code is doing so instead of doing these
in this code-base just let the six module (which
is widely used for this purpose) handle these types
of version differences.