### PR TITLE
Added a function so we can retrieve the IP address from a MAC using a host instead of a lease

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,29 @@ def get_lease(omapi, ip):
     return response
 ```
 
+#Get an IP from a host MAC address
+
+```
+def lookup_ip_host(self, mac):
+    """Lookup a host object with with given mac address.
+
+    @type mac: str
+    @raises ValueError:
+    @raises OmapiError:
+    @raises socket.error:
+    """
+    msg = OmapiMessage.open(b"host")
+    msg.obj.append((b"hardware-address", pack_mac(mac)))
+    msg.obj.append((b"hardware-type", struct.pack("!I", 1)))
+    response = self.query_server(msg)
+    if response.opcode != OMAPI_OP_UPDATE:
+        raise OmapiErrorNotFound()
+    try:
+        return unpack_ip(dict(response.obj)[b"ip-address"])
+    except KeyError:  # ip-address
+        raise OmapiErrorNotFound()
+```
+
 #Change Group
 
 ```

--- a/pypureomapi.py
+++ b/pypureomapi.py
@@ -1090,7 +1090,7 @@ class Omapi(object):
 		if response.opcode != OMAPI_OP_STATUS:
 			raise OmapiError("delete failed")
 
-        def lookup_ip_host(self, mac):
+	def lookup_ip_host(self, mac):
                 """Lookup a host object with with given mac address.
 
                 @type mac: str

--- a/pypureomapi.py
+++ b/pypureomapi.py
@@ -1090,6 +1090,25 @@ class Omapi(object):
 		if response.opcode != OMAPI_OP_STATUS:
 			raise OmapiError("delete failed")
 
+        def lookup_ip_host(self, mac):
+                """Lookup a host object with with given mac address.
+
+                @type mac: str
+                @raises ValueError:
+                @raises OmapiError:
+                @raises socket.error:
+                """
+                msg = OmapiMessage.open(b"host")
+                msg.obj.append((b"hardware-address", pack_mac(mac)))
+                msg.obj.append((b"hardware-type", struct.pack("!I", 1)))
+                response = self.query_server(msg)
+                if response.opcode != OMAPI_OP_UPDATE:
+                        raise OmapiErrorNotFound()
+                try:
+                        return unpack_ip(dict(response.obj)[b"ip-address"])
+                except KeyError:  # ip-address
+                        raise OmapiErrorNotFound()
+
 	def lookup_ip(self, mac):
 		"""Look for a lease object with given mac address and return the
 		assigned ip address.


### PR DESCRIPTION
The current version of pypureomapi only supports querying a lease object, in modifications presented in this pull request, I have added near identical functionality but for a host object instead.

Best,
-William Turner