### PR TITLE
added lookup_hostname and add_host_without_ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,51 @@ def add_host_supersede_name(omapi, ip, mac, name):
 
 Similarly the router can be superseded. 
 
+#add host declaration without static ip
+```
+def add_host_without_ip(self, mac):
+    """Create a host object with given mac address without assigning a static ip address.
+
+        @type ip: str
+        @type mac: str
+        @raises ValueError:
+        @raises OmapiError:
+        @raises socket.error:
+        """
+        msg = OmapiMessage.open(b"host")
+        msg.message.append((b"create", struct.pack("!I", 1)))
+        msg.message.append((b"exclusive", struct.pack("!I", 1)))
+        msg.obj.append((b"hardware-address", pack_mac(mac)))
+        msg.obj.append((b"hardware-type", struct.pack("!I", 1)))
+        response = self.query_server(msg)
+        if response.opcode != OMAPI_OP_UPDATE:
+            raise OmapiError("add failed")
+```
+
+#lookup hostname based on ip address
+```
+def lookup_hostname(self, ip):
+    """Look up a lease object with given ip address and return the associated client hostname.
+
+        @type ip: str
+        @rtype: str or None
+        @raises ValueError:
+        @raises OmapiError:
+        @raises OmapiErrorNotFound: if no lease object with the given ip
+        address could be found or the object lacks a hostname
+        @raises socket.error:
+        """
+        msg = OmapiMessage.open(b"lease")
+        msg.obj.append((b"ip-address", pack_ip(ip)))
+        response = self.query_server(msg)
+        if response.opcode != OMAPI_OP_UPDATE:
+            raise OmapiErrorNotFound()
+        try:
+            return (dict(response.obj)[b"client-hostname"])
+        except KeyError:  # client hostname
+            raise OmapiErrorNotFound()
+```
+
 #Get a lease
 
 Original idea from Josh West.


### PR DESCRIPTION
i have added following functions to pypureomapi:
1. lookup_hostname-> this is in parallel to lookup_ip and lookup_mac. It looks up hostname based on ip address of the client.
2. add_host_without_ip -> this adds host declaration without the static IP address. A client passes known-clients filter in a pool if it has a host declaration. By adding host declarations without static IP we can make dhcp assign addresses from 2 different pools for known-client(with host declaration) and unknown-clients(without host declaration);
pool {
deny unknown-clients;
..
}
pool {
allow unknown-clients;
..
}