### PR TITLE
add host lookup from mac address

### DIFF
--- a/pypureomapi.py
+++ b/pypureomapi.py
@@ -1211,7 +1211,7 @@ class Omapi(object):
 		@type ip: str
 		@type mac: str
 		@type name: str
-		@rtype: dict or None
+		@rtype: dict or str (for a single key) or None
 		@raises ValueError:
 		@raises OmapiError:
 		@raises OmapiErrorNotFound: if no host object with the given name
@@ -1239,6 +1239,8 @@ class Omapi(object):
 				if elem == 'name':
 					hostname = dict(response.obj)[b"name"]
 					result['hostname'] = hostname.decode('utf-8')
+			if len(result) == 1:
+				result = list(result.values())[0]
 			return result
 		except KeyError:
 			raise OmapiErrorNotFound()

--- a/pypureomapi.py
+++ b/pypureomapi.py
@@ -1203,7 +1203,7 @@ class Omapi(object):
 		"""
 		msg = OmapiMessage.open(b"host")
 		msg.obj.append((b"hardware-address", pack_mac(mac)))
-        msg.obj.append((b"hardware-type", struct.pack("!I", 1)))
+		msg.obj.append((b"hardware-type", struct.pack("!I", 1)))
 		response = self.query_server(msg)
 		if response.opcode != OMAPI_OP_UPDATE:
 			raise OmapiErrorNotFound()

--- a/pypureomapi.py
+++ b/pypureomapi.py
@@ -1211,7 +1211,7 @@ class Omapi(object):
 		@type ip: str
 		@type mac: str
 		@type name: str
-		@rtype: dict or str (for a single key) or None
+		@rtype: dict or str (if len(rvalues) == 1) or None
 		@raises ValueError:
 		@raises OmapiError:
 		@raises OmapiErrorNotFound: if no host object with the given name


### PR DESCRIPTION
PR adds a method to lookup a host reservation from a given mac address and returns ip, mac and hostname. Method is 95% the same as lookup_host but takes in a mac address. 