### PR TITLE
Fix for underscore to dash conversion

### DIFF
--- a/pypureomapi.py
+++ b/pypureomapi.py
@@ -1214,7 +1214,7 @@ class Omapi(object):  # pylint:disable=too-many-public-methods
 			elif _k == "name":
 				msg.obj.append((b"name", kwargs[k].encode('utf-8')))
 			else:
-				msg.obj.append((str(k).encode(), kwargs[k].encode('utf-8')))
+				msg.obj.append((str(_k).encode(), kwargs[k].encode('utf-8')))
 		response = self.query_server(msg)
 		if response.opcode != OMAPI_OP_UPDATE:
 			raise OmapiErrorNotFound()


### PR DESCRIPTION
DHCP OMAPI normally uses dashes as a separator for field words. Python does not accept dashes in kwarg keys, so there is a conversion in the `__lookup` function to convert _ to -. However, there seems to be a bug that prevents that conversion to be actually used for some parameters.

Tested on one of instances of dhcpd and I saw the right names (e.g. `client-hostname`) in the dump. (However not all fields are supported in ISC in the lookup.)