### PR TITLE
Fix TypeError: a bytes-like object is required, not 'str'

### DIFF
--- a/pypureomapi.py
+++ b/pypureomapi.py
@@ -1311,7 +1311,7 @@ class Omapi(object):  # pylint:disable=too-many-public-methods
 
 		msg = OmapiMessage.open(b"host")
 		msg.message.append((b"create", struct.pack("!I", 1)))
-		msg.obj.append((b"name", name))
+		msg.obj.append((b"name", name.encode('utf-8')))
 		msg.obj.append((b"hardware-address", pack_mac(mac)))
 		msg.obj.append((b"hardware-type", struct.pack("!I", 1)))
 		msg.obj.append((b"ip-address", pack_ip(ip)))


### PR DESCRIPTION
Using add_host_supersede raise traceback with Type Error.

```
Traceback (most recent call last):
  File "manage_dhcp.py", line 99, in <module>
    main(sys.argv)
  File "manage_dhcp.py", line 92, in main
    add_soft_lease(omapi, lease)
  File "manage_dhcp.py", line 65, in add_soft_lease
    omapi.add_host_supersede(str(host['IPAddress']), str(host['ClientID']).replace('-', ':'), str(host['HostName']))
  File "/home/mn.albeschenko/Yandex.Disk/Work/Projects/dhcp-manage/venv/lib/python3.6/site-packages/pypureomapi.py", line 1326, in add_host_supersede
    response = self.query_server(msg)
  File "/home/mn.albeschenko/Yandex.Disk/Work/Projects/dhcp-manage/venv/lib/python3.6/site-packages/pypureomapi.py", line 1053, in query_server
    self.send_message(message)
  File "/home/mn.albeschenko/Yandex.Disk/Work/Projects/dhcp-manage/venv/lib/python3.6/site-packages/pypureomapi.py", line 1044, in send_message
    self.protocol.send_message(message, sign)
  File "/home/mn.albeschenko/Yandex.Disk/Work/Projects/dhcp-manage/venv/lib/python3.6/site-packages/pypureomapi.py", line 944, in send_message
    message.sign(self.authenticators[self.defauth])
  File "/home/mn.albeschenko/Yandex.Disk/Work/Projects/dhcp-manage/venv/lib/python3.6/site-packages/pypureomapi.py", line 466, in sign
    self.signature = authenticator.sign(self.as_string(forsigning=True))
  File "/home/mn.albeschenko/Yandex.Disk/Work/Projects/dhcp-manage/venv/lib/python3.6/site-packages/pypureomapi.py", line 457, in as_string
    self.serialize(ret, forsigning)
  File "/home/mn.albeschenko/Yandex.Disk/Work/Projects/dhcp-manage/venv/lib/python3.6/site-packages/pypureomapi.py", line 443, in serialize
    outbuffer.add_bindict(self.obj)
  File "/home/mn.albeschenko/Yandex.Disk/Work/Projects/dhcp-manage/venv/lib/python3.6/site-packages/pypureomapi.py", line 212, in add_bindict
    self.add_net16string(key).add_net32string(value)
  File "/home/mn.albeschenko/Yandex.Disk/Work/Projects/dhcp-manage/venv/lib/python3.6/site-packages/pypureomapi.py", line 183, in add_net32string
    return self.add_net32int(len(string)).add(string)
  File "/home/mn.albeschenko/Yandex.Disk/Work/Projects/dhcp-manage/venv/lib/python3.6/site-packages/pypureomapi.py", line 145, in add
    self.buff.write(data)
TypeError: a bytes-like object is required, not 'str'
```

